### PR TITLE
Implement a shader profiler in NIR

### DIFF
--- a/src/amd/llvm/ac_llvm_helper.cpp
+++ b/src/amd/llvm/ac_llvm_helper.cpp
@@ -192,7 +192,11 @@ struct ac_compiler_passes *ac_create_llvm_passes(LLVMTargetMachineRef tm)
 
 	if (TM->addPassesToEmitFile(p->passmgr, p->ostream,
 				    nullptr,
+#if LLVM_VERSION_MAJOR >= 10
+				    llvm::CGFT_ObjectFile)) {
+#else
 				    llvm::TargetMachine::CGFT_ObjectFile)) {
+#endif
 		fprintf(stderr, "amd: TargetMachine can't emit a file of this type!\n");
 		delete p;
 		return NULL;

--- a/src/compiler/glsl/link_uniform_blocks.cpp
+++ b/src/compiler/glsl/link_uniform_blocks.cpp
@@ -29,6 +29,7 @@
 #include "program.h"
 #include "main/errors.h"
 #include "main/mtypes.h"
+#include "main/shader_time.h"
 
 namespace {
 
@@ -533,9 +534,21 @@ link_cross_validate_uniform_block(void *mem_ctx,
    for (unsigned int i = 0; i < *num_linked_blocks; i++) {
       struct gl_uniform_block *old_block = &(*linked_blocks)[i];
 
-      if (strcmp(old_block->Name, new_block->Name) == 0)
+      if (strcmp(old_block->Name, new_block->Name) == 0) {
+         /* TODO: This is a workaround for the way I am currently creating the
+          * extra block, because it is duplicated with different bindings so
+          * here I simply choose the highest one.
+          * Since there is a limited amount of bindings available, we need to
+          * to find a way to add the extra SSBO that doesn't mess with the
+          * bindings and preferably also does not touch the IR. */
+         if (strcmp(old_block->Name, SHADER_TIME_IFACE_NAME) == 0) {
+            int max_binding = MAX2(old_block->Binding, new_block->Binding);
+            old_block->Binding = max_binding;
+            new_block->Binding = max_binding;
+         }
          return link_uniform_blocks_are_compatible(old_block, new_block)
             ? i : -1;
+      }
    }
 
    *linked_blocks = reralloc(mem_ctx, *linked_blocks,

--- a/src/compiler/glsl/linker.cpp
+++ b/src/compiler/glsl/linker.cpp
@@ -90,6 +90,8 @@
 #include "main/shaderobj.h"
 #include "main/enums.h"
 #include "main/mtypes.h"
+#include "main/shader_time.h"
+#include "main/shaderapi.h"
 
 
 namespace {
@@ -2524,13 +2526,29 @@ link_intrastage_shaders(void *mem_ctx,
    linked->Program->info.num_ubos = num_ubo_blocks;
 
    /* Copy ssbo blocks to linked shader list */
-   linked->Program->sh.ShaderStorageBlocks =
-      ralloc_array(linked, gl_uniform_block *, num_ssbo_blocks);
+   /* If shader profiling is enabled, we also add an SSBO at index 0 */
    ralloc_steal(linked, ssbo_blocks);
-   for (unsigned i = 0; i < num_ssbo_blocks; i++) {
-      linked->Program->sh.ShaderStorageBlocks[i] = &ssbo_blocks[i];
+   linked->Program->info.num_ssbos =
+      ctx->shader_profiling_enabled ?  num_ssbo_blocks+1 : num_ssbo_blocks;
+   linked->Program->sh.ShaderStorageBlocks =
+      ralloc_array(linked, gl_uniform_block*, linked->Program->info.num_ssbos);
+   struct gl_uniform_block *ssbo_prof_block = NULL;
+   if (ctx->shader_profiling_enabled) {
+      GLuint highest_bind = 0;
+      for (unsigned i = 0; i < num_ssbo_blocks; i++) {
+         if (ssbo_blocks[i].Binding >= highest_bind) {
+            highest_bind = ssbo_blocks[i].Binding;
+         }
+      }
+      ssbo_prof_block = _mesa_create_shader_time_block(linked, highest_bind+1);
    }
-   linked->Program->info.num_ssbos = num_ssbo_blocks;
+   if (ssbo_prof_block) {
+      linked->Program->sh.ShaderStorageBlocks[0] = ssbo_prof_block;
+   }
+   for (unsigned i = 0; i < num_ssbo_blocks; i++) {
+      int idx = ssbo_prof_block ? i+1 : i;
+      linked->Program->sh.ShaderStorageBlocks[idx] = &ssbo_blocks[i];
+   }
 
    /* At this point linked should contain all of the linked IR, so
     * validate it to make sure nothing went wrong.

--- a/src/compiler/glsl/meson.build
+++ b/src/compiler/glsl/meson.build
@@ -208,6 +208,7 @@ files_libglsl = files(
   'serialize.h',
   'shader_cache.cpp',
   'shader_cache.h',
+  'shader_time.cpp'
 )
 
 files_libglsl_standalone = files(

--- a/src/compiler/glsl/shader_time.cpp
+++ b/src/compiler/glsl/shader_time.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2019 Igalia S.L.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "main/mtypes.h"
+#include "main/shader_time.h"
+#include "compiler/glsl_types.h"
+
+/**
+ * Creates an SSBO block for MESA_SHADER_TIME and returns a pointer to it.
+ *
+ * This block is a uint64_t array with length = MESA_SHADER_STAGES.
+ * Each element will be used to store the number of cycles the shader program
+ * takes to execute.
+ */
+struct gl_uniform_block *
+_mesa_create_shader_time_block(void *ctx, GLuint binding)
+{
+   struct gl_uniform_block *block =
+      rzalloc_array(ctx, struct gl_uniform_block, 1);
+   struct gl_uniform_buffer_variable *extra_uniforms_info =
+      rzalloc_array(ctx, struct gl_uniform_buffer_variable, 1);
+
+   block->Name = ralloc_strdup(ctx, SHADER_TIME_IFACE_NAME);
+   block->NumUniforms = 1;
+   block->Uniforms = extra_uniforms_info;
+   // TODO: generate random interface and variable name
+   block->Uniforms[0].Name =
+      ralloc_strdup(ctx, SHADER_TIME_IFACE_NAME "." SHADER_TIME_VAR_NAME);
+   block->Uniforms[0].IndexName =
+      ralloc_strdup(ctx, SHADER_TIME_IFACE_NAME "." SHADER_TIME_VAR_NAME);
+
+   static const glsl_struct_field field[] = {
+      glsl_struct_field(glsl_type::get_array_instance(
+                           glsl_type::uint64_t_type, MESA_SHADER_STAGES, 0),
+                        SHADER_TIME_VAR_NAME)
+   };
+   block->Uniforms[0].Type =
+      glsl_type::get_interface_instance(field, ARRAY_SIZE(field),
+                                        GLSL_INTERFACE_PACKING_STD430,
+                                        false, SHADER_TIME_IFACE_NAME);
+   block->Uniforms[0].Offset = 0;
+   block->Uniforms[0].RowMajor = 0;
+
+   block->Binding = binding;
+   block->UniformBufferSize =
+      MESA_SHADER_STAGES * glsl_type::uint64_t_type->std430_size(0);
+   block->stageref = 0;
+   block->linearized_array_index = 0;
+   block->_Packing = GLSL_INTERFACE_PACKING_STD430;
+   block->_RowMajor = 0;
+
+   return block;
+}
+

--- a/src/compiler/nir/meson.build
+++ b/src/compiler/nir/meson.build
@@ -120,6 +120,7 @@ files_libnir = files(
   'nir_lower_bitmap.c',
   'nir_lower_bool_to_float.c',
   'nir_lower_bool_to_int32.c',
+  'nir_shader_time.c',
   'nir_lower_clamp_color_outputs.c',
   'nir_lower_clip.c',
   'nir_lower_clip_cull_distance_arrays.c',

--- a/src/compiler/nir/nir.h
+++ b/src/compiler/nir/nir.h
@@ -3727,6 +3727,8 @@ bool nir_lower_regs_to_ssa_impl(nir_function_impl *impl);
 bool nir_lower_regs_to_ssa(nir_shader *shader);
 bool nir_lower_vars_to_ssa(nir_shader *shader);
 
+void nir_shader_time(nir_shader *shader);
+
 bool nir_remove_dead_derefs(nir_shader *shader);
 bool nir_remove_dead_derefs_impl(nir_function_impl *impl);
 bool nir_remove_dead_variables(nir_shader *shader, nir_variable_mode modes);

--- a/src/compiler/nir/nir_shader_time.c
+++ b/src/compiler/nir/nir_shader_time.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2019 Igalia S.L.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "nir.h"
+#include "nir_builder.h"
+
+/*
+ * This pass measures the time taken for each shader stage and stores it
+ * on the SSBO with block_index 0.
+ *
+ * It is assumed that this SSBO block_index has been allocated properly
+ * beforehand.
+ */
+
+static void
+nir_shader_time_impl(nir_shader *shader, nir_function_impl *impl)
+{
+   nir_builder b;
+   nir_builder_init(&b, impl);
+
+   // get timestamp at the start of this shader stage
+   nir_block *first_block = nir_start_block(impl);
+   b.cursor = nir_before_block(first_block);
+   nir_intrinsic_instr *start_instr =
+      nir_intrinsic_instr_create(shader, nir_intrinsic_shader_clock);
+   nir_ssa_dest_init(&start_instr->instr, &start_instr->dest, 2, 32, NULL);
+   nir_builder_instr_insert(&b, &start_instr->instr);
+   nir_ssa_def *packed_start = nir_pack_64_2x32(&b, &start_instr->dest.ssa);
+
+   // get timestamp at the end of this shader stage
+   nir_block *last_block = nir_impl_last_block(impl);
+   b.cursor = nir_after_block(last_block);
+   nir_intrinsic_instr *end_instr =
+      nir_intrinsic_instr_create(shader, nir_intrinsic_shader_clock);
+   nir_ssa_dest_init(&end_instr->instr, &end_instr->dest, 2, 32, NULL);
+   nir_builder_instr_insert(&b, &end_instr->instr);
+   nir_ssa_def *packed_end = nir_pack_64_2x32(&b, &end_instr->dest.ssa);
+
+   // subtract both timestamps
+   nir_ssa_def *elapsed = nir_isub(&b, packed_end, packed_start);
+
+   // accumulate result in the array position given by
+   // the "shader->info.stage" enum
+   nir_intrinsic_instr *store_ssbo =
+      nir_intrinsic_instr_create(shader, nir_intrinsic_ssbo_atomic_add);
+   store_ssbo->num_components = 1;
+   store_ssbo->src[0] = nir_src_for_ssa(nir_imm_int(&b, 0));
+   // 8 bytes for each stage (uint64)
+   store_ssbo->src[1] =
+      nir_src_for_ssa(nir_imm_int(&b, shader->info.stage * 8));
+   store_ssbo->src[2] = nir_src_for_ssa(elapsed);
+   // TODO: figure out why "32" is the only valid value here,
+   //       specially because our ssbo is a uint64
+   //
+   //       It appears that the intel backend has an assert for 32,
+   //       so it will crash if we put 64 there.
+   nir_ssa_dest_init(&store_ssbo->instr, &store_ssbo->dest,
+                     store_ssbo->num_components, 32, NULL);
+   nir_builder_instr_insert(&b, &store_ssbo->instr);
+}
+
+void
+nir_shader_time(nir_shader *shader)
+{
+   assert(shader);
+
+   nir_shader_time_impl(shader, nir_shader_get_entrypoint(shader));
+}

--- a/src/intel/compiler/brw_nir.c
+++ b/src/intel/compiler/brw_nir.c
@@ -814,6 +814,10 @@ brw_postprocess_nir(nir_shader *nir, const struct brw_compiler *compiler,
 
    UNUSED bool progress; /* Written by OPT */
 
+   // TODO: can this get called even if gl_context->shader_profiling_enabled is false somehow?
+   if (getenv("MESA_SHADER_TIME"))
+      NIR_PASS_V(nir, nir_shader_time);
+
    OPT(brw_nir_lower_mem_access_bit_sizes);
 
    do {

--- a/src/mesa/drivers/dri/i965/brw_context.c
+++ b/src/mesa/drivers/dri/i965/brw_context.c
@@ -996,6 +996,8 @@ brwCreateContext(gl_api api,
       intelDestroyContext(driContextPriv);
       return false;
    }
+   if (getenv("MESA_SHADER_TIME"))
+      ctx->shader_profiling_enabled = true;
 
    driContextSetFlags(ctx, ctx_config->flags);
 

--- a/src/mesa/main/bufferobj.c
+++ b/src/mesa/main/bufferobj.c
@@ -1414,8 +1414,8 @@ bind_buffer_base_uniform_buffer(struct gl_context *ctx,
  * Bind a buffer object to a shader storage block binding point.
  * As above, but offset = 0.
  */
-static void
-bind_buffer_base_shader_storage_buffer(struct gl_context *ctx,
+void
+_mesa_bind_buffer_base_shader_storage_buffer(struct gl_context *ctx,
                                        GLuint index,
                                        struct gl_buffer_object *bufObj)
 {
@@ -1541,8 +1541,8 @@ delete_buffers(struct gl_context *ctx, GLsizei n, const GLuint *ids)
          /* unbind SSBO binding points */
          for (j = 0; j < ctx->Const.MaxShaderStorageBufferBindings; j++) {
             if (ctx->ShaderStorageBufferBindings[j].BufferObject == bufObj) {
-               bind_buffer_base_shader_storage_buffer(ctx, j,
-                                                    ctx->Shared->NullBufferObj);
+               _mesa_bind_buffer_base_shader_storage_buffer(ctx, j,
+                                                   ctx->Shared->NullBufferObj);
             }
          }
 
@@ -4644,7 +4644,7 @@ _mesa_BindBufferBase(GLenum target, GLuint index, GLuint buffer)
       bind_buffer_base_uniform_buffer(ctx, index, bufObj);
       return;
    case GL_SHADER_STORAGE_BUFFER:
-      bind_buffer_base_shader_storage_buffer(ctx, index, bufObj);
+      _mesa_bind_buffer_base_shader_storage_buffer(ctx, index, bufObj);
       return;
    case GL_ATOMIC_COUNTER_BUFFER:
       bind_buffer_base_atomic_buffer(ctx, index, bufObj);

--- a/src/mesa/main/bufferobj.h
+++ b/src/mesa/main/bufferobj.h
@@ -104,6 +104,11 @@ _mesa_multi_bind_lookup_bufferobj(struct gl_context *ctx,
                                   GLuint index, const char *caller);
 
 extern void
+_mesa_bind_buffer_base_shader_storage_buffer(struct gl_context *ctx,
+                                       GLuint index,
+                                       struct gl_buffer_object *bufObj);
+
+extern void
 _mesa_initialize_buffer_object(struct gl_context *ctx,
                                struct gl_buffer_object *obj,
                                GLuint name);

--- a/src/mesa/main/context.c
+++ b/src/mesa/main/context.c
@@ -143,6 +143,7 @@
 #include "main/dispatch.h" /* for _gloffset_COUNT */
 #include "macros.h"
 #include "git_sha1.h"
+#include "shader_time.h"
 
 #ifdef USE_SPARC_ASM
 #include "sparc/sparc.h"
@@ -415,6 +416,8 @@ one_time_init( struct gl_context *ctx )
    }
 
    api_init_mask |= 1 << ctx->API;
+
+   ctx->shader_profiling_enabled = false;
 
    mtx_unlock(&OneTimeLock);
 }
@@ -876,6 +879,7 @@ init_attrib_groups(struct gl_context *ctx)
    _mesa_init_varray( ctx );
    _mesa_init_viewport( ctx );
    _mesa_init_resident_handles( ctx );
+   _mesa_init_shader_times( ctx );
 
    if (!_mesa_init_texture( ctx ))
       return GL_FALSE;
@@ -1368,6 +1372,7 @@ _mesa_free_context_data(struct gl_context *ctx, bool destroy_compiler_types)
    _mesa_free_performance_monitors(ctx);
    _mesa_free_performance_queries(ctx);
    _mesa_free_resident_handles(ctx);
+   _mesa_free_shader_times(ctx);
 
    _mesa_reference_buffer_object(ctx, &ctx->Pack.BufferObj, NULL);
    _mesa_reference_buffer_object(ctx, &ctx->Unpack.BufferObj, NULL);

--- a/src/mesa/main/draw.c
+++ b/src/mesa/main/draw.c
@@ -40,6 +40,10 @@
 #include "enums.h"
 #include "macros.h"
 #include "transformfeedback.h"
+#include "program_resource.h"
+#include "shaderapi.h"
+#include "get.h"
+#include "shader_time.h"
 
 typedef struct {
    GLuint count;
@@ -2153,8 +2157,10 @@ _mesa_driver_draw(struct gl_context *ctx,
                   GLuint min_index, GLuint max_index,
                   struct gl_transform_feedback_object *tfb_vertcount,
                   unsigned tfb_stream, struct gl_buffer_object *indirect) {
+   _mesa_prepare_shader_time_buffer(ctx);
    ctx->Driver.Draw(ctx, prims, nr_prims, ib, index_bounds_valid, min_index,
                     max_index, tfb_vertcount, tfb_stream, indirect);
+   _mesa_collect_and_report_shader_time(ctx);
 }
 
 void
@@ -2165,7 +2171,9 @@ _mesa_driver_draw_indirect(struct gl_context *ctx, GLuint mode,
                            struct gl_buffer_object *indirect_draw_count_buffer,
                            GLsizeiptr indirect_draw_count_offset,
                            const struct _mesa_index_buffer *ib) {
+   _mesa_prepare_shader_time_buffer(ctx);
    ctx->Driver.DrawIndirect(ctx, mode, indirect_data, indirect_offset,
                             draw_count, stride, indirect_draw_count_buffer,
                             indirect_draw_count_offset, ib);
+   _mesa_collect_and_report_shader_time(ctx);
 }

--- a/src/mesa/main/draw.c
+++ b/src/mesa/main/draw.c
@@ -371,8 +371,8 @@ _mesa_draw_arrays(struct gl_context *ctx, GLenum mode, GLint start,
    prim.start = start;
    prim.count = count;
 
-   ctx->Driver.Draw(ctx, &prim, 1, NULL,
-                    GL_TRUE, start, start + count - 1, NULL, 0, NULL);
+   _mesa_driver_draw(ctx, &prim, 1, NULL,
+                     GL_TRUE, start, start + count - 1, NULL, 0, NULL);
 
    if (MESA_DEBUG_FLAGS & DEBUG_ALWAYS_FLUSH) {
       _mesa_flush(ctx);
@@ -813,8 +813,8 @@ _mesa_validated_drawrangeelements(struct gl_context *ctx, GLenum mode,
     * for the latter case elsewhere.
     */
 
-   ctx->Driver.Draw(ctx, &prim, 1, &ib,
-                    index_bounds_valid, start, end, NULL, 0, NULL);
+   _mesa_driver_draw(ctx, &prim, 1, &ib,
+                     index_bounds_valid, start, end, NULL, 0, NULL);
 
    if (MESA_DEBUG_FLAGS & DEBUG_ALWAYS_FLUSH) {
       _mesa_flush(ctx);
@@ -1246,8 +1246,8 @@ _mesa_validated_multidrawelements(struct gl_context *ctx, GLenum mode,
             prim[i].basevertex = 0;
       }
 
-      ctx->Driver.Draw(ctx, prim, primcount, &ib,
-                       false, 0, ~0, NULL, 0, NULL);
+      _mesa_driver_draw(ctx, prim, primcount, &ib,
+                        false, 0, ~0, NULL, 0, NULL);
    }
    else {
       /* render one prim at a time */
@@ -1275,7 +1275,7 @@ _mesa_validated_multidrawelements(struct gl_context *ctx, GLenum mode,
          else
             prim[0].basevertex = 0;
 
-         ctx->Driver.Draw(ctx, prim, 1, &ib, false, 0, ~0, NULL, 0, NULL);
+         _mesa_driver_draw(ctx, prim, 1, &ib, false, 0, ~0, NULL, 0, NULL);
       }
    }
 
@@ -1393,7 +1393,7 @@ _mesa_draw_transform_feedback(struct gl_context *ctx, GLenum mode,
     * (like in DrawArrays), but we have no way to know how many vertices
     * will be rendered. */
 
-   ctx->Driver.Draw(ctx, &prim, 1, NULL, GL_FALSE, 0, ~0, obj, stream, NULL);
+   _mesa_driver_draw(ctx, &prim, 1, NULL, GL_FALSE, 0, ~0, obj, stream, NULL);
 
    if (MESA_DEBUG_FLAGS & DEBUG_ALWAYS_FLUSH) {
       _mesa_flush(ctx);
@@ -1477,10 +1477,10 @@ static void
 _mesa_validated_drawarraysindirect(struct gl_context *ctx,
                                    GLenum mode, const GLvoid *indirect)
 {
-   ctx->Driver.DrawIndirect(ctx, mode,
-                            ctx->DrawIndirectBuffer, (GLsizeiptr) indirect,
-                            1 /* draw_count */ , 16 /* stride */ ,
-                            NULL, 0, NULL);
+   _mesa_driver_draw_indirect(ctx, mode,
+                              ctx->DrawIndirectBuffer, (GLsizeiptr) indirect,
+                              1 /* draw_count */ , 16 /* stride */ ,
+                              NULL, 0, NULL);
 
    if (MESA_DEBUG_FLAGS & DEBUG_ALWAYS_FLUSH)
       _mesa_flush(ctx);
@@ -1498,8 +1498,8 @@ _mesa_validated_multidrawarraysindirect(struct gl_context *ctx,
    if (primcount == 0)
       return;
 
-   ctx->Driver.DrawIndirect(ctx, mode, ctx->DrawIndirectBuffer, offset,
-                            primcount, stride, NULL, 0, NULL);
+   _mesa_driver_draw_indirect(ctx, mode, ctx->DrawIndirectBuffer, offset,
+                              primcount, stride, NULL, 0, NULL);
 
    if (MESA_DEBUG_FLAGS & DEBUG_ALWAYS_FLUSH)
       _mesa_flush(ctx);
@@ -1518,10 +1518,10 @@ _mesa_validated_drawelementsindirect(struct gl_context *ctx,
    ib.obj = ctx->Array.VAO->IndexBufferObj;
    ib.ptr = NULL;
 
-   ctx->Driver.DrawIndirect(ctx, mode,
-                            ctx->DrawIndirectBuffer, (GLsizeiptr) indirect,
-                            1 /* draw_count */ , 20 /* stride */ ,
-                            NULL, 0, &ib);
+   _mesa_driver_draw_indirect(ctx, mode,
+                             ctx->DrawIndirectBuffer, (GLsizeiptr) indirect,
+                             1 /* draw_count */ , 20 /* stride */ ,
+                             NULL, 0, &ib);
 
    if (MESA_DEBUG_FLAGS & DEBUG_ALWAYS_FLUSH)
       _mesa_flush(ctx);
@@ -1547,9 +1547,9 @@ _mesa_validated_multidrawelementsindirect(struct gl_context *ctx,
    ib.obj = ctx->Array.VAO->IndexBufferObj;
    ib.ptr = NULL;
 
-   ctx->Driver.DrawIndirect(ctx, mode,
-                            ctx->DrawIndirectBuffer, offset,
-                            primcount, stride, NULL, 0, &ib);
+   _mesa_driver_draw_indirect(ctx, mode,
+                              ctx->DrawIndirectBuffer, offset,
+                              primcount, stride, NULL, 0, &ib);
 
    if (MESA_DEBUG_FLAGS & DEBUG_ALWAYS_FLUSH)
       _mesa_flush(ctx);
@@ -1829,10 +1829,10 @@ _mesa_validated_multidrawarraysindirectcount(struct gl_context *ctx,
    if (maxdrawcount == 0)
       return;
 
-   ctx->Driver.DrawIndirect(ctx, mode,
-                            ctx->DrawIndirectBuffer, offset,
-                            maxdrawcount, stride,
-                            ctx->ParameterBuffer, drawcount_offset, NULL);
+   _mesa_driver_draw_indirect(ctx, mode,
+                              ctx->DrawIndirectBuffer, offset,
+                              maxdrawcount, stride,
+                              ctx->ParameterBuffer, drawcount_offset, NULL);
 
    if (MESA_DEBUG_FLAGS & DEBUG_ALWAYS_FLUSH)
       _mesa_flush(ctx);
@@ -1860,10 +1860,10 @@ _mesa_validated_multidrawelementsindirectcount(struct gl_context *ctx,
    ib.obj = ctx->Array.VAO->IndexBufferObj;
    ib.ptr = NULL;
 
-   ctx->Driver.DrawIndirect(ctx, mode,
-                            ctx->DrawIndirectBuffer, offset,
-                            maxdrawcount, stride,
-                            ctx->ParameterBuffer, drawcount_offset, &ib);
+   _mesa_driver_draw_indirect(ctx, mode,
+                              ctx->DrawIndirectBuffer, offset,
+                              maxdrawcount, stride,
+                              ctx->ParameterBuffer, drawcount_offset, &ib);
 
    if (MESA_DEBUG_FLAGS & DEBUG_ALWAYS_FLUSH)
       _mesa_flush(ctx);
@@ -2100,8 +2100,8 @@ draw_indirect(struct gl_context *ctx, GLuint mode,
    /* This should always be true at this time */
    assert(indirect_data == ctx->DrawIndirectBuffer);
 
-   ctx->Driver.Draw(ctx, prim, draw_count, ib, false, 0u, ~0u,
-                    NULL, 0, indirect_data);
+   _mesa_driver_draw(ctx, prim, draw_count, ib, false, 0u, ~0u,
+                     NULL, 0, indirect_data);
 }
 
 
@@ -2143,4 +2143,29 @@ _mesa_draw_indirect(struct gl_context *ctx, GLuint mode,
 
       free(space);
    }
+}
+
+void
+_mesa_driver_draw(struct gl_context *ctx,
+                  const struct _mesa_prim *prims, GLuint nr_prims,
+                  const struct _mesa_index_buffer *ib,
+                  GLboolean index_bounds_valid,
+                  GLuint min_index, GLuint max_index,
+                  struct gl_transform_feedback_object *tfb_vertcount,
+                  unsigned tfb_stream, struct gl_buffer_object *indirect) {
+   ctx->Driver.Draw(ctx, prims, nr_prims, ib, index_bounds_valid, min_index,
+                    max_index, tfb_vertcount, tfb_stream, indirect);
+}
+
+void
+_mesa_driver_draw_indirect(struct gl_context *ctx, GLuint mode,
+                           struct gl_buffer_object *indirect_data,
+                           GLsizeiptr indirect_offset, unsigned draw_count,
+                           unsigned stride,
+                           struct gl_buffer_object *indirect_draw_count_buffer,
+                           GLsizeiptr indirect_draw_count_offset,
+                           const struct _mesa_index_buffer *ib) {
+   ctx->Driver.DrawIndirect(ctx, mode, indirect_data, indirect_offset,
+                            draw_count, stride, indirect_draw_count_buffer,
+                            indirect_draw_count_offset, ib);
 }

--- a/src/mesa/main/draw.h
+++ b/src/mesa/main/draw.h
@@ -152,6 +152,23 @@ _mesa_MultiModeDrawElementsIBM(const GLenum * mode, const GLsizei * count,
                                GLsizei primcount, GLint modestride);
 
 
+void GLAPIENTRY
+_mesa_driver_draw(struct gl_context *ctx,
+                  const struct _mesa_prim *prims, GLuint nr_prims,
+                  const struct _mesa_index_buffer *ib,
+                  GLboolean index_bounds_valid,
+                  GLuint min_index, GLuint max_index,
+                  struct gl_transform_feedback_object *tfb_vertcount,
+                  unsigned tfb_stream, struct gl_buffer_object *indirect);
+
+void GLAPIENTRY
+_mesa_driver_draw_indirect(struct gl_context *ctx, GLuint mode,
+                           struct gl_buffer_object *indirect_data,
+                           GLsizeiptr indirect_offset, unsigned draw_count,
+                           unsigned stride,
+                           struct gl_buffer_object *indirect_draw_count_buffer,
+                           GLsizeiptr indirect_draw_count_offset,
+                           const struct _mesa_index_buffer *ib);
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/mesa/main/mtypes.h
+++ b/src/mesa/main/mtypes.h
@@ -4798,6 +4798,11 @@ struct gl_semaphore_object
    GLuint Name;            /**< hash table ID/name */
 };
 
+struct _gl_shader_time
+{
+   uint64_t Stages[MESA_SHADER_STAGES];
+};
+
 /**
  * Mesa rendering context.
  *
@@ -5178,6 +5183,22 @@ struct gl_context
    struct hash_table_u64 *ResidentTextureHandles;
    struct hash_table_u64 *ResidentImageHandles;
    /*@}*/
+
+   /**
+    * Stores shader time profiling information.
+    */
+   bool shader_profiling_enabled;
+   struct {
+      struct gl_buffer_object *BufObj;
+      double LastReportTime;
+      int *Ids;
+      struct _gl_shader_time *Times;
+      int NumEntries;
+      /* Maximum number of entries allocated in Times and Ids */
+      int MaxEntries;
+      /* used to preserve gl user state */
+      struct gl_buffer_object *PreviouslyBoundBufObj;
+   } ShaderTimes;
 
    bool shader_builtin_ref;
 };

--- a/src/mesa/main/shader_time.c
+++ b/src/mesa/main/shader_time.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2019 Igalia S.L.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <c99_alloca.h>
+#include <assert.h>
+
+#include "shaderapi.h"
+#include "bufferobj.h"
+#include "shader_time.h"
+#include "context.h"
+#include "get.h"
+#include "compiler/glsl_types.h"
+
+/**
+ * Init/free per-context shader times.
+ */
+void
+_mesa_init_shader_times(struct gl_context *ctx)
+{
+   ctx->ShaderTimes.BufObj = ctx->Driver.NewBufferObject(ctx,
+                                                         SHADER_TIME_BUF_ID);
+
+   if (!ctx->ShaderTimes.BufObj) {
+      _mesa_problem(ctx, "Failed to create MESA_SHADER_TIME buffer object.");
+      return;
+   }
+
+   uint64_t data[MESA_SHADER_STAGES] = {0};
+   if (!ctx->Driver.BufferData(ctx, GL_SHADER_STORAGE_BUFFER, sizeof(data),
+                               data, GL_DYNAMIC_COPY,
+                               GL_MAP_WRITE_BIT | GL_MAP_READ_BIT,
+                               ctx->ShaderTimes.BufObj)) {
+      _mesa_error_no_memory(__func__);
+      return;
+   }
+
+   ctx->ShaderTimes.LastReportTime = -1.0f;
+   ctx->ShaderTimes.NumEntries = 0;
+   ctx->ShaderTimes.MaxEntries = SHADER_TIME_INIT_ARR_COUNT;
+   ctx->ShaderTimes.Ids = malloc(ctx->ShaderTimes.MaxEntries *
+                                 sizeof(*ctx->ShaderTimes.Ids));
+   ctx->ShaderTimes.Times = malloc(ctx->ShaderTimes.MaxEntries *
+                                   sizeof(*ctx->ShaderTimes.Times));
+}
+
+void
+_mesa_free_shader_times(struct gl_context *ctx)
+{
+   if (ctx->ShaderTimes.Ids)
+      free(ctx->ShaderTimes.Ids);
+   if (ctx->ShaderTimes.Times)
+      free(ctx->ShaderTimes.Times);
+   if (ctx->ShaderTimes.BufObj)
+      ctx->Driver.DeleteBuffer(ctx, ctx->ShaderTimes.BufObj);
+}
+
+void
+_mesa_prepare_shader_time_buffer(struct gl_context *ctx)
+{
+   assert(ctx);
+   if (!ctx->shader_profiling_enabled || !ctx->_Shader->ActiveProgram)
+      return;
+
+   struct gl_buffer_object *bo = ctx->ShaderTimes.BufObj;
+
+   // find the binding point for the ssbo which has block_index == 0
+   GLint binding_point = -1;
+   GLenum props = GL_BUFFER_BINDING;
+   GLint length = 1;
+   struct gl_shader_program *shProg = ctx->_Shader->ActiveProgram;
+   _mesa_get_program_resourceiv(shProg, GL_SHADER_STORAGE_BLOCK,
+                                0, 1, &props, sizeof(props),
+                                &length, &binding_point);
+
+   GLint previous_bufobj_id = -1;
+   _mesa_GetIntegerv(GL_SHADER_STORAGE_BUFFER_BINDING,
+                     &previous_bufobj_id);
+   if (previous_bufobj_id != -1) {
+      ctx->ShaderTimes.PreviouslyBoundBufObj = _mesa_lookup_bufferobj(
+         ctx, previous_bufobj_id);
+   } else {
+      ctx->ShaderTimes.PreviouslyBoundBufObj = NULL;
+   }
+
+   // this assumes the binding point has been selected so that no conflicts
+   // occur, such as using the same binding point that the client uses
+   _mesa_bind_buffer_base_shader_storage_buffer(ctx, binding_point, bo);
+}
+
+static void
+collect_shader_time(struct gl_context *ctx)
+{
+   struct gl_buffer_object *bo = ctx->ShaderTimes.BufObj;
+
+   // preserve gl user state
+   if (ctx->ShaderTimes.PreviouslyBoundBufObj) {
+      _mesa_reference_buffer_object(ctx, &ctx->ShaderStorageBuffer,
+                                    ctx->ShaderTimes.PreviouslyBoundBufObj);
+   }
+
+   GLvoid *p = ctx->Driver.MapBufferRange(ctx, 0, bo->Size,
+                                          GL_MAP_READ_BIT | GL_MAP_WRITE_BIT,
+                                          bo, MAP_INTERNAL);
+   uint64_t data[MESA_SHADER_STAGES];
+   memcpy(data, p, sizeof(data));
+
+   GLuint id = ctx->_Shader->ActiveProgram->Name;
+   bool new_program = true;
+   for (int i = 0; i < ctx->ShaderTimes.NumEntries; i++) {
+      if (ctx->ShaderTimes.Ids[i] == id) {
+         new_program = false;
+         for (int j = 0; j < MESA_SHADER_STAGES; j++) {
+            ctx->ShaderTimes.Times[i].Stages[j] += data[j];
+         }
+         break;
+      }
+   }
+   if (new_program) {
+      int index = ctx->ShaderTimes.NumEntries++;
+      ctx->ShaderTimes.Ids[index] = id;
+      for (int j = 0; j < MESA_SHADER_STAGES; j++) {
+         ctx->ShaderTimes.Times[index].Stages[j] = data[j];
+      }
+
+      if (ctx->ShaderTimes.NumEntries == ctx->ShaderTimes.MaxEntries) {
+         ctx->ShaderTimes.MaxEntries += SHADER_TIME_INIT_ARR_COUNT;
+         ctx->ShaderTimes.Ids = realloc(ctx->ShaderTimes.Ids,
+                                        ctx->ShaderTimes.MaxEntries *
+                                        sizeof(*ctx->ShaderTimes.Ids));
+         ctx->ShaderTimes.Times = realloc(ctx->ShaderTimes.Times,
+                                          ctx->ShaderTimes.MaxEntries *
+                                          sizeof(*ctx->ShaderTimes.Times));
+         if (!ctx->ShaderTimes.Ids || !ctx->ShaderTimes.Times)
+            _mesa_error_no_memory(__func__);
+      }
+   }
+
+   memset(p, 0, sizeof(data));
+
+   ctx->Driver.UnmapBuffer(ctx, bo, MAP_INTERNAL);
+}
+
+static void
+report_shader_time(struct gl_context *ctx)
+{
+   double totalCycles = 0;
+   for (int i = 0; i < ctx->ShaderTimes.NumEntries; i++) {
+      for (int j = 0; j < MESA_SHADER_STAGES; j++) {
+         totalCycles += ctx->ShaderTimes.Times[i].Stages[j];
+      }
+   }
+
+   uint64_t totals[MESA_SHADER_STAGES] = {0};
+
+   fprintf(stderr, "-----------------------------------------------------\n");
+   fprintf(stderr, "type\t\tID\tcycles\t\t   %% of total\n");
+   fprintf(stderr, "-----------------------------------------------------\n");
+   for (int i = 0; i < ctx->ShaderTimes.NumEntries; i++) {
+      GLuint id = ctx->ShaderTimes.Ids[i];
+      uint64_t *times = ctx->ShaderTimes.Times[i].Stages;
+      for (int stage = 0; stage < MESA_SHADER_STAGES; stage++) {
+         if (times[stage]) {
+            fprintf(stderr, "%s\t\t%d\t%-19lu%lf%%\n",
+                   _mesa_shader_stage_to_abbrev(stage), id,
+                   times[stage], 100*times[stage]/totalCycles);
+            totals[stage] += times[stage];
+         }
+      }
+   }
+   fprintf(stderr, "-----------------------------------------------------\n");
+   for (int stage = 0; stage < MESA_SHADER_STAGES; stage++) {
+      fprintf(stderr, "Total %s\t\t%-19lu%lf%%\n",
+             _mesa_shader_stage_to_abbrev(stage),
+             totals[stage], 100*totals[stage]/totalCycles);
+   }
+   fprintf(stderr, "-----------------------------------------------------\n");
+}
+
+void
+_mesa_collect_and_report_shader_time(struct gl_context *ctx)
+{
+   if (!ctx->shader_profiling_enabled || !ctx->_Shader->ActiveProgram)
+      return;
+
+   assert(ctx);
+
+   collect_shader_time(ctx);
+
+   struct timespec tp;
+   clock_gettime(CLOCK_MONOTONIC, &tp);
+   double curTime = tp.tv_sec + tp.tv_nsec / 1000000000.0;
+
+   if (ctx->ShaderTimes.LastReportTime < 0) {
+      ctx->ShaderTimes.LastReportTime = curTime;
+   } else if (curTime - ctx->ShaderTimes.LastReportTime > 3.0f) {
+      ctx->ShaderTimes.LastReportTime = curTime;
+      report_shader_time(ctx);
+   }
+}
+

--- a/src/mesa/main/shader_time.h
+++ b/src/mesa/main/shader_time.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2019 Igalia S.L.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef SHADER_TIME_H
+#define SHADER_TIME_H
+
+#include "main/glheader.h"
+
+/* just IDs/strings that stands out when debugging */
+#define SHADER_TIME_BUF_ID 21212
+#define SHADER_TIME_INIT_ARR_COUNT 5
+#define SHADER_TIME_IFACE_NAME "__shaderTimeIFaceName"
+#define SHADER_TIME_VAR_NAME "__shaderTimeVarName"
+
+struct gl_context;
+
+extern void
+_mesa_init_shader_times(struct gl_context *ctx);
+
+extern void
+_mesa_free_shader_times(struct gl_context *ctx);
+
+extern void
+_mesa_prepare_shader_time_buffer(struct gl_context *ctx);
+
+extern void
+_mesa_collect_and_report_shader_time(struct gl_context *ctx);
+
+extern struct gl_uniform_block *
+_mesa_create_shader_time_block(void *ctx, GLuint binding);
+
+#endif /* SHADER_TIME_H */

--- a/src/mesa/meson.build
+++ b/src/mesa/meson.build
@@ -240,6 +240,8 @@ files_libmesa_common = files(
   'main/samplerobj.h',
   'main/scissor.c',
   'main/scissor.h',
+  'main/shader_time.c',
+  'main/shader_time.h',
   'main/shaderapi.c',
   'main/shaderapi.h',
   'main/shaderimage.c',

--- a/src/mesa/vbo/vbo_exec_api.c
+++ b/src/mesa/vbo/vbo_exec_api.c
@@ -1251,6 +1251,12 @@ vbo_exec_FlushVertices(struct gl_context *ctx, GLuint flags)
 {
    struct vbo_exec_context *exec = &vbo_context(ctx)->exec;
 
+   /* when shader profiling is enabled, a double flush can happen
+    * because we must change some buffer bindings, this is a workaround
+    * to avoid that */
+   if (ctx->shader_profiling_enabled && exec->flush_call_depth > 0)
+      return;
+
 #ifndef NDEBUG
    /* debug check: make sure we don't get called recursively */
    exec->flush_call_depth++;

--- a/src/mesa/vbo/vbo_exec_draw.c
+++ b/src/mesa/vbo/vbo_exec_draw.c
@@ -383,9 +383,9 @@ vbo_exec_vtx_flush(struct vbo_exec_context *exec, GLboolean keepUnmapped)
             printf("%s %d %d\n", __func__, exec->vtx.prim_count,
                    exec->vtx.vert_count);
 
-         ctx->Driver.Draw(ctx, exec->vtx.prim, exec->vtx.prim_count,
-                          NULL, GL_TRUE, 0, exec->vtx.vert_count - 1,
-                          NULL, 0, NULL);
+         _mesa_driver_draw(ctx, exec->vtx.prim, exec->vtx.prim_count,
+                           NULL, GL_TRUE, 0, exec->vtx.vert_count - 1,
+                           NULL, 0, NULL);
 
          /* Get new storage -- unless asked not to. */
          if (!keepUnmapped)

--- a/src/mesa/vbo/vbo_primitive_restart.c
+++ b/src/mesa/vbo/vbo_primitive_restart.c
@@ -247,13 +247,13 @@ vbo_sw_primitive_restart(struct gl_context *ctx,
             temp_prim.count = MIN2(sub_end_index, end_index) - temp_prim.start;
             if ((temp_prim.start == sub_prim->start) &&
                 (temp_prim.count == sub_prim->count)) {
-               ctx->Driver.Draw(ctx, &temp_prim, 1, ib, GL_TRUE,
-                                sub_prim->min_index, sub_prim->max_index,
-                                NULL, 0, NULL);
+               _mesa_driver_draw(ctx, &temp_prim, 1, ib, GL_TRUE,
+                                 sub_prim->min_index, sub_prim->max_index,
+                                 NULL, 0, NULL);
             } else {
-               ctx->Driver.Draw(ctx, &temp_prim, 1, ib,
-                                GL_FALSE, -1, -1,
-                                NULL, 0, NULL);
+               _mesa_driver_draw(ctx, &temp_prim, 1, ib,
+                                 GL_FALSE, -1, -1,
+                                 NULL, 0, NULL);
             }
          }
          if (sub_end_index >= end_index) {

--- a/src/mesa/vbo/vbo_save_draw.c
+++ b/src/mesa/vbo/vbo_save_draw.c
@@ -212,8 +212,8 @@ vbo_save_playback_vertex_list(struct gl_context *ctx, void *data)
       if (node->vertex_count > 0) {
          GLuint min_index = _vbo_save_get_min_index(node);
          GLuint max_index = _vbo_save_get_max_index(node);
-         ctx->Driver.Draw(ctx, node->prims, node->prim_count, NULL, GL_TRUE,
-                          min_index, max_index, NULL, 0, NULL);
+         _mesa_driver_draw(ctx, node->prims, node->prim_count, NULL, GL_TRUE,
+                           min_index, max_index, NULL, 0, NULL);
       }
    }
 

--- a/src/util/disk_cache.c
+++ b/src/util/disk_cache.c
@@ -217,6 +217,14 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
    if (env_var_as_boolean("MESA_GLSL_CACHE_DISABLE", false))
       goto fail;
 
+   /* When shader profiling is on, disable shader cache entirely. */
+   // TODO: this currently disables the shader cache even if the driver
+   //       does not support shader profiling, but only if the envvar is set.
+   //       if needed we can do it per-backend like INTEL_DEBUG=shader_time:
+   //       https://gitlab.freedesktop.org/mesa/mesa/commit/3887700dfd7597fba654a4a713c274213a4a8755
+   if (env_var_as_boolean("MESA_SHADER_TIME", false))
+      goto fail;
+
    cache = rzalloc(NULL, struct disk_cache);
    if (cache == NULL)
       goto fail;


### PR DESCRIPTION
## [WIP] Shader profiling in NIR using ARB_shader_clock

### Introduction
This patch is intended to be a reimplementation of `INTEL_DEBUG=shader_time` but using NIR and the `ARB_shader_clock` extension. This would allow us to reuse the profiling code on any mesa driver that supports that extension, and remove intel-specific code from the intel driver.

This way, other mesa backends that meet the requirements (NIR and `ARB_shader_clock`) will be able to add a shader profiling feature via the `MESA_SHADER_TIME` environment variable, which would be the mesa generic equivalent to the intel specific `INTEL_DEBUG=shader_time`.

### Results
I ran a simple program for a similar amount of time using both INTEL_DEBUG=shader_time and MESA_SHADER_TIME, but not both at the same execution, because that would mess with the results.

![INTEL_DEBUG=shader_time](https://i.imgur.com/U17yc5k.png)

![MESA_SHADER_TIME](https://i.imgur.com/Wq8fjCY.png)

### Implementation
This was implemented by adding a NIR pass that injects some profiling code into the shader and stores the result in a SSBO via the `ssbo_atomic_add()` intrinsic.

As we want to support multiple shader programs, after the program finishes running we read the result from the SSBO and store it in a buffer that is indexed by the shader program ID. This data can be found inside `struct gl_context`.

Every time a draw call happens, a SSBO that has `MESA_SHADER_STAGES` `uint64_t` variables is bound and after the draw call ends we accumulate the recorded value for each stage in that particular shader program to the buffer inside `struct gl_context`. If a new shader program is created, we just reallocate the buffer on the fly to accomodate for it.

Also, it's important that we disable the glsl shader cache to force shader recompilation when `MESA_SHADER_TIME` is on.

But for all of this to work, the SSBO must first be declared/created with a known `block_index` and `binding_point`. The binding point is needed because we must bind the SSBO every time a draw call happens. The block index is needed because the NIR pass must add the `ssbo_atomic_add()` instruction, and that instruction requires a block index to operate on.

Unfortunately, creating an SSBO inside the NIR pass doesn't work, as the linking stage won't reserve space for it. Thus, the SSBO with the required properties must be created in some other way.

Currently, this is happening on `glsl/linker.cpp` by adding one extra SSBO block at index 0 in the middle of the linker pipeline. The binding point is selected by looping over all other variables and giving the SSBO the `highest_binding_point+1`. As the binding point is being queried at runtime by calling `get_program_resourceiv()` and the NIR code doesn't explicitly use the binding point, we just need to give it any binding point that isn't being used.

### Current status / Missing work
With all that being said, the SSBO creation code is not working as intended, causing test regressions and crashes. This is probably because adding an extra block to `ShaderStorageBlocks` at `struct gl_program` isn't the proper way to allocate an extra SSBO, causing weird things to happen when we write to it.

Also, the binding point selection code must be improved, because the way it's currently implemented it can generate a SSBO with a binding point that is over the maximum number of possible binding points, but this is not the main cause of the test failures or crashes.

### Regressions / Piglit test results
The current implementation has the following piglit test results on the "quick" test suite:

    [41454/41454] skip: 4434, pass: 35200, warn: 12, fail: 1799, crash: 8
    https://pastebin.com/raw/AbHtvut7

Note: A small portion of those tests also fail by default on upstream mesa, although most are in fact regressions.